### PR TITLE
Resolve reference error and remove unnecessary test check

### DIFF
--- a/internal/services/compute/disk_encryption_set_data_source.go
+++ b/internal/services/compute/disk_encryption_set_data_source.go
@@ -66,8 +66,8 @@ func dataSourceDiskEncryptionSetRead(d *pluginsdk.ResourceData, meta interface{}
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
-	if props := resp.Properties; props != nil {
-		d.Set("auto_key_rotation_enabled", props.rotationToLatestKeyVersionEnabled)
+	if props := resp.EncryptionSetProperties; props != nil {
+		d.Set("auto_key_rotation_enabled", props.RotationToLatestKeyVersionEnabled)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/internal/services/compute/disk_encryption_set_data_source_test.go
+++ b/internal/services/compute/disk_encryption_set_data_source_test.go
@@ -32,20 +32,13 @@ func TestAccDataSourceDiskEncryptionSet_update(t *testing.T) {
 	r := DiskEncryptionSetDataSource{}
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.update(data),
+			Config: r.basic(data),
 		},
 		{
-			Config: r.update(data),
+			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("location").Exists(),
 				check.That(data.ResourceName).Key("auto_key_rotation_enabled").HasValue("true"),
-			),
-		},
-		{
-			Config: r.update(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("location").Exists(),
-				check.That(data.ResourceName).Key("auto_key_rotation_enabled").HasValue("false"),
 			),
 		},
 	})
@@ -62,7 +55,7 @@ data "azurerm_disk_encryption_set" "test" {
 `, DiskEncryptionSetResource{}.basic(data))
 }
 
-func (DiskEncryptionSetDataSource) update(data acceptance.TestData) string {
+func (DiskEncryptionSetDataSource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -70,5 +63,5 @@ data "azurerm_disk_encryption_set" "test" {
   name                = azurerm_disk_encryption_set.test.name
   resource_group_name = azurerm_disk_encryption_set.test.resource_group_name
 }
-`, DiskEncryptionSetResource{}.update(data))
+`, DiskEncryptionSetResource{}.complete(data))
 }

--- a/internal/services/compute/disk_encryption_set_resource.go
+++ b/internal/services/compute/disk_encryption_set_resource.go
@@ -144,6 +144,7 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 					ID: utils.String(keyVaultDetails.keyVaultId),
 				},
 			},
+			RotationToLatestKeyVersionEnabled: &rotationToLatestKeyVersionEnabled,
 		},
 		Identity: expandDiskEncryptionSetIdentity(identityRaw),
 		Tags:     tags.Expand(t),
@@ -201,7 +202,7 @@ func resourceDiskEncryptionSetRead(d *pluginsdk.ResourceData, meta interface{}) 
 			keyVaultKeyId = *props.ActiveKey.KeyURL
 		}
 		d.Set("key_vault_key_id", keyVaultKeyId)
-		d.Set("auto_key_rotation_enabled", props.rotationToLatestKeyVersionEnabled)
+		d.Set("auto_key_rotation_enabled", props.RotationToLatestKeyVersionEnabled)
 	}
 
 	if err := d.Set("identity", flattenDiskEncryptionSetIdentity(resp.Identity)); err != nil {
@@ -255,7 +256,7 @@ func resourceDiskEncryptionSetUpdate(d *pluginsdk.ResourceData, meta interface{}
 			update.DiskEncryptionSetUpdateProperties = &compute.DiskEncryptionSetUpdateProperties{}
 		}
 
-		update.DiskEncryptionSetUpdateProperties.rotationToLatestKeyVersionEnabled = utils.Bool(d.Get("auto_key_rotation_enabled").(bool))
+		update.DiskEncryptionSetUpdateProperties.RotationToLatestKeyVersionEnabled = utils.Bool(d.Get("auto_key_rotation_enabled").(bool))
 	}
 
 	future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)

--- a/internal/services/compute/disk_encryption_set_resource_test.go
+++ b/internal/services/compute/disk_encryption_set_resource_test.go
@@ -55,15 +55,6 @@ func TestAccDiskEncryptionSet_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("auto_key_rotation_enabled").HasValue("true"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.complete(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("auto_key_rotation_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -86,7 +77,6 @@ func TestAccDiskEncryptionSet_update(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("auto_key_rotation_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -94,7 +84,6 @@ func TestAccDiskEncryptionSet_update(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("auto_key_rotation_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -126,7 +115,6 @@ func TestAccDiskEncryptionSet_keyRotate(t *testing.T) {
 			Config: r.keyRotate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("auto_key_rotation_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),


### PR DESCRIPTION
- Fix names:
  - `rotationToLatestKeyVersionEnabled` to `RotationToLatestKeyVersionEnabled`
  - `Properties` to `EncryptionSetProperties`
- Remove unnecessary `check.That()` for this property in the resource test, it will be verified in importStep. For data source test, kept it since it's `Computed` in data source
- Update test steps