### PR TITLE
Fix tests

### DIFF
--- a/internal/services/compute/disk_encryption_set_data_source_test.go
+++ b/internal/services/compute/disk_encryption_set_data_source_test.go
@@ -17,11 +17,9 @@ func TestAccDataSourceDiskEncryptionSet_basic(t *testing.T) {
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
-		},
-		{
-			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("location").Exists(),
+				check.That(data.ResourceName).Key("auto_key_rotation_enabled").HasValue("false"),
 			),
 		},
 	})


### PR DESCRIPTION
- Resource config definition update
  - Move `resource "azurerm_key_vault_access_policy" "disk-encryption" { ...` block to `dependencies` config, to avoid the duplicate definition of this resource. Earlier this resource is only needed for key rotate, but now the update of the new flag `auto_key_rotation_enabled` also requires this, and since in the [document](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/website/docs/r/disk_encryption_set.html.markdown#example-usage), it is already present, I'm moving it to the common resource dependencies, to make it simple to write the update and keyRotate test
  - Here is failed test output before this change
```
------ Stdout: -------
=== RUN   TestAccDiskEncryptionSet_update
=== PAUSE TestAccDiskEncryptionSet_update
=== CONT  TestAccDiskEncryptionSet_update
testcase.go:108: Step 3/6 error: Error running apply: exit status 1
Error: updating Disk Encryption Set "acctestDES-211019081335747893" (Resource Group "acctestRG-211019081335747893"): compute.DiskEncryptionSetsClient#Update: Failure sending request: StatusCode=400 -- Original Error: Code="KeyVaultAccessForbidden" Message="Unable to access key vault 'https://acctestkv-rzdvo.vault.azure.net/keys/examplekey'"
with azurerm_disk_encryption_set.test,
on terraform_plugin_test.tf line 69, in resource "azurerm_disk_encryption_set" "test":
69: resource "azurerm_disk_encryption_set" "test" {
--- FAIL: TestAccDiskEncryptionSet_update (385.25s)
FAIL
```
- TestAccDataSourceDiskEncryptionSet_basic
  - Remove the duplicate basic config
  - Add check for default value of computed auto_key_rotation_enabled
- TestAccDiskEncryptionSet_update
  - Remove duplicated complete config
- TestAccDiskEncryptionSet_keyRotate
  - Remove grantAccessToKeyVault config after the move of `azurerm_key_vault_access_policy` resource, as it is now a common resource in `dependencies`, which will be present across all config.
- Test results:
```
$ make acctests SERVICE='compute' TESTARGS='-run=DiskEncryptionSet_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/compute -run=DiskEncryptionSet_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceDiskEncryptionSet_basic
=== PAUSE TestAccDataSourceDiskEncryptionSet_basic
=== RUN   TestAccDataSourceDiskEncryptionSet_update
=== PAUSE TestAccDataSourceDiskEncryptionSet_update
=== RUN   TestAccDiskEncryptionSet_basic
=== PAUSE TestAccDiskEncryptionSet_basic
=== RUN   TestAccDiskEncryptionSet_requiresImport
=== PAUSE TestAccDiskEncryptionSet_requiresImport
=== RUN   TestAccDiskEncryptionSet_complete
=== PAUSE TestAccDiskEncryptionSet_complete
=== RUN   TestAccDiskEncryptionSet_update
=== PAUSE TestAccDiskEncryptionSet_update
=== RUN   TestAccDiskEncryptionSet_keyRotate
=== PAUSE TestAccDiskEncryptionSet_keyRotate
=== CONT  TestAccDataSourceDiskEncryptionSet_basic
=== CONT  TestAccDiskEncryptionSet_complete
=== CONT  TestAccDiskEncryptionSet_keyRotate
=== CONT  TestAccDataSourceDiskEncryptionSet_update
=== CONT  TestAccDiskEncryptionSet_update
=== CONT  TestAccDiskEncryptionSet_basic
=== CONT  TestAccDiskEncryptionSet_requiresImport
--- PASS: TestAccDiskEncryptionSet_complete (530.87s)
--- PASS: TestAccDiskEncryptionSet_basic (532.79s)
--- PASS: TestAccDataSourceDiskEncryptionSet_basic (545.35s)
--- PASS: TestAccDiskEncryptionSet_requiresImport (620.24s)
--- PASS: TestAccDataSourceDiskEncryptionSet_update (712.04s)
--- PASS: TestAccDiskEncryptionSet_update (726.25s)
--- PASS: TestAccDiskEncryptionSet_keyRotate (755.83s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       756.524s
```